### PR TITLE
Add Apple service center page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,46 @@
-.container {
+.page-container {
   max-width: 960px;
   margin: 0 auto;
-  padding: 2rem 1rem;
+  padding: 1rem;
 }
 
 .header {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
   margin-bottom: 2rem;
+}
+.logo {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+.nav {
+  display: flex;
+  gap: 1rem;
+}
+.burger {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+}
+.messengers span {
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .nav {
+    display: none;
+    flex-direction: column;
+    margin-top: 0.5rem;
+  }
+  .nav.open {
+    display: flex;
+  }
+  .burger {
+    display: block;
+  }
 }
 
 .hero {
@@ -15,21 +49,23 @@
 }
 
 .features {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
   margin-bottom: 2rem;
 }
-
 .feature {
-  flex: 1 1 200px;
-  padding: 1rem;
   border: 1px solid #ddd;
   border-radius: 8px;
+  padding: 1rem;
+}
+
+.faq details {
+  margin-bottom: 0.5rem;
 }
 
 .contact {
+  text-align: center;
   margin-bottom: 2rem;
 }
 
@@ -37,4 +73,49 @@
   text-align: center;
   font-size: 0.9rem;
   color: #555;
+  padding-top: 1rem;
+  border-top: 1px solid #eee;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 90%;
+  position: relative;
+}
+.close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+}
+.form label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+.form input,
+.form select,
+.form textarea {
+  width: 100%;
+  margin-top: 0.25rem;
+  padding: 0.4rem;
+  box-sizing: border-box;
+}
+.success {
+  text-align: center;
+}
+.policy {
+  font-size: 0.8rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,37 +1,145 @@
+import { useState } from 'react'
 import './App.css'
 
 function App() {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  const toggleModal = () => {
+    setModalOpen(!modalOpen)
+    setSubmitted(false)
+  }
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setSubmitted(true)
+  }
+
   return (
-    <div className="container">
+    <div className="page-container">
       <header className="header">
-        <h1>AppleMake Service Center</h1>
+        <div className="logo">AppleMake</div>
+        <nav className="nav" id="nav">
+          <a href="#service">Сервисный центр</a>
+          <a href="#guarantee">Гарантия</a>
+          <a href="#delivery">Доставка и оплата</a>
+          <a href="#bonus">Бонусная программа</a>
+          <a href="#contacts">Контакты</a>
+        </nav>
+        <button className="burger" onClick={() => document.getElementById('nav')?.classList.toggle('open')}>☰</button>
+        <div className="messengers">
+          <span aria-label="Telegram" role="img">\uD83D\uDCAC</span>
+          <span aria-label="WhatsApp" role="img">\uD83D\uDCF1</span>
+        </div>
       </header>
+
       <section className="hero">
-        <h2>Repair &amp; Care for your Apple devices</h2>
-        <p>Professional services for iPhone, iPad, Mac and more.</p>
+        <h1>Сервисный центр техники Apple</h1>
+        <h2>Собственная лаборатория. Первоклассные инженеры. Оригинальные запчасти.</h2>
+        <button onClick={toggleModal}>Оставить заявку</button>
       </section>
+
       <section className="features">
         <div className="feature">
-          <h3>Diagnostic</h3>
-          <p>We quickly determine what your device needs.</p>
+          <h3>Бесплатная диагностика</h3>
+          <p>Проверим устройство и назовем стоимость ремонта.</p>
         </div>
         <div className="feature">
-          <h3>Fast Repair</h3>
-          <p>High‑quality parts and reliable service.</p>
+          <h3>Честная гарантия</h3>
+          <p>Гарантийные сроки фиксируются в документе.</p>
         </div>
         <div className="feature">
-          <h3>Warranty</h3>
-          <p>All repairs are covered by our guarantee.</p>
+          <h3>Инженеры</h3>
+          <p>Сложные поломки решают сертифицированные специалисты.</p>
+        </div>
+        <div className="feature">
+          <h3>Комфорт</h3>
+          <p>Уютный сервис и парковка для клиентов.</p>
         </div>
       </section>
-      <section className="contact">
-        <h2>Contact Us</h2>
-        <p>Email: support@applemake.example</p>
-        <p>Phone: +1 555-123-4567</p>
+
+      <section className="faq">
+        <h2>FAQ</h2>
+        <details>
+          <summary>Какие устройства мы обслуживаем?</summary>
+          <p>iPhone, iPad, Mac, Watch и другую технику Apple.</p>
+        </details>
+        <details>
+          <summary>Как будет происходить обслуживание устройства?</summary>
+          <p>После диагностики мы согласуем стоимость и сроки ремонта.</p>
+        </details>
+        <details>
+          <summary>Как долго моё устройство будет на обслуживании?</summary>
+          <p>Срок зависит от сложности поломки и наличия запчастей.</p>
+        </details>
       </section>
+
+      <section className="contact" id="contacts">
+        <h2>Свяжитесь с нами</h2>
+        <p>Телефон: <a href="tel:+79267776277">+7 (926) 777‑62‑77</a></p>
+        <p>График работы: ежедневно 10:00–21:00</p>
+        <p>Адрес: Москва, ул. Барклая 7 корп. 4</p>
+        <p>Email: <a href="mailto:info@appletrade.ru">info@appletrade.ru</a></p>
+        <button onClick={toggleModal}>Оставить заявку</button>
+      </section>
+
       <footer className="footer">
-        <p>&copy; 2025 AppleMake</p>
+        <nav>
+          <a href="#service">Сервисный центр</a>
+          <a href="#guarantee">Гарантия</a>
+          <a href="#delivery">Доставка и оплата</a>
+          <a href="#bonus">Бонусная программа</a>
+          <a href="#contacts">Контакты</a>
+        </nav>
+        <div className="messengers">
+          <span aria-label="Telegram" role="img">\uD83D\uDCAC</span>
+          <span aria-label="WhatsApp" role="img">\uD83D\uDCF1</span>
+        </div>
+        <p className="legal">AppleMake не является авторизованным сервисным центром Apple. Все товарные знаки принадлежат их правообладателям.</p>
       </footer>
+
+      {modalOpen && (
+        <div className="modal" role="dialog">
+          <div className="modal-content">
+            <button className="close" onClick={toggleModal}>×</button>
+            {submitted ? (
+              <p className="success">Спасибо! Ваша заявка принята.</p>
+            ) : (
+              <form onSubmit={handleSubmit} className="form">
+                <h3>Заявка на обслуживание</h3>
+                <label>
+                  ФИО
+                  <input type="text" required />
+                </label>
+                <label>
+                  Телефон
+                  <input type="tel" required />
+                </label>
+                <label>
+                  Способ связи
+                  <select>
+                    <option value="wa">WhatsApp</option>
+                    <option value="tg">Telegram</option>
+                    <option value="call">Перезвонить</option>
+                  </select>
+                </label>
+                <label>
+                  Тип устройства
+                  <input type="text" />
+                </label>
+                <label>
+                  Описание неисправности
+                  <textarea rows={3}></textarea>
+                </label>
+                <label className="policy">
+                  <input type="checkbox" required /> Я согласен с обработкой персональных данных
+                </label>
+                <button type="submit">Отправить</button>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- design Apple service center homepage with React
- style layout and modal in CSS

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6851a85555208333bdfa563141d9d17a